### PR TITLE
Add first version of handler

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,11 @@
+module github.com/MichelHollands/slogTracer
+
+go 1.22.5
+
+require github.com/stretchr/testify v1.9.0
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,9 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/handler.go
+++ b/handler.go
@@ -1,0 +1,65 @@
+package slogTracer
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+)
+
+type contextKey string
+
+func extractHeader(ctx context.Context, header string) (string, bool) {
+	var headerName = contextKey(header)
+	header, ok := ctx.Value(headerName).(string)
+	return header, ok
+}
+
+var _ slog.Handler = (*Handler)(nil)
+
+type Handler struct {
+	handler slog.Handler
+	header  string
+	value   string
+}
+
+func NewHandler(handler slog.Handler, headerName, expected string) Handler {
+	return Handler{
+		handler: handler,
+		header:  headerName,
+		value:   expected,
+	}
+}
+
+func (h Handler) valid(ctx context.Context) bool {
+	header, ok := extractHeader(ctx, h.header)
+	if !ok {
+		return false
+	}
+	// HTTP headers are case insensitive
+	if strings.EqualFold(header, h.value) {
+		return true
+	}
+	return false
+}
+
+func (h Handler) Enabled(ctx context.Context, level slog.Level) bool {
+	if h.valid(ctx) && level >= slog.LevelDebug {
+		return true
+	}
+	return h.handler.Enabled(ctx, level)
+}
+
+func (h Handler) Handle(ctx context.Context, record slog.Record) error {
+	return h.handler.Handle(ctx, record)
+}
+
+func (h Handler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return Handler{
+		handler: h.handler.WithAttrs(attrs),
+		value:   h.value,
+	}
+}
+
+func (h Handler) WithGroup(name string) slog.Handler {
+	return h.handler.WithGroup(name)
+}

--- a/handler_test.go
+++ b/handler_test.go
@@ -1,0 +1,80 @@
+package slogTracer
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValid(t *testing.T) {
+	handler := slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError})
+	tracerHandler := NewHandler(handler, "X-SlogTracer", "abc")
+
+	emptyCtx := context.Background()
+	assert.False(t, tracerHandler.valid(emptyCtx))
+
+	ctx := context.WithValue(context.Background(), contextKey("X-SlogTracer"), "abc")
+	assert.True(t, tracerHandler.valid(ctx))
+}
+
+func TestLogging(t *testing.T) {
+	var sb strings.Builder
+	handler := slog.NewTextHandler(&sb, &slog.HandlerOptions{Level: slog.LevelError})
+	tracerHandler := NewHandler(handler, "X-SlogTracer", "abc")
+	logger := slog.New(tracerHandler)
+	validCtx := context.WithValue(context.Background(), contextKey("X-SlogTracer"), "abc")
+	invalidCtx := context.WithValue(context.Background(), contextKey("X-SlogTracer"), "def")
+	emptyCtx := context.Background()
+
+	logger.ErrorContext(validCtx, "should print")
+	assert.Contains(t, sb.String(), "should print")
+	sb.Reset()
+
+	logger.ErrorContext(invalidCtx, "should print")
+	assert.Contains(t, sb.String(), "should print")
+	sb.Reset()
+
+	logger.ErrorContext(emptyCtx, "should print")
+	assert.Contains(t, sb.String(), "should print")
+	sb.Reset()
+
+	logger.WarnContext(validCtx, "should print")
+	assert.Contains(t, sb.String(), "should print")
+	sb.Reset()
+
+	logger.WarnContext(invalidCtx, "should not print")
+	assert.NotContains(t, sb.String(), "should not print")
+	sb.Reset()
+
+	logger.WarnContext(emptyCtx, "should not print")
+	assert.NotContains(t, sb.String(), "should not print")
+	sb.Reset()
+
+	logger.InfoContext(validCtx, "should print")
+	assert.Contains(t, sb.String(), "should print")
+	sb.Reset()
+
+	logger.InfoContext(invalidCtx, "should not print")
+	assert.NotContains(t, sb.String(), "should not print")
+	sb.Reset()
+
+	logger.InfoContext(emptyCtx, "should not print")
+	assert.NotContains(t, sb.String(), "should not print")
+	sb.Reset()
+
+	logger.DebugContext(validCtx, "should print")
+	assert.Contains(t, sb.String(), "should print")
+	sb.Reset()
+
+	logger.DebugContext(invalidCtx, "should not print")
+	assert.NotContains(t, sb.String(), "should not print")
+	sb.Reset()
+
+	logger.DebugContext(emptyCtx, "should not print")
+	assert.NotContains(t, sb.String(), "should not print")
+	sb.Reset()
+}


### PR DESCRIPTION
The handler receives a header name and value to match in the context. If the context contains a Value matching these it will allow a debug level logging (and higher).