### PR TITLE
Use different context variable

### DIFF
--- a/context.go
+++ b/context.go
@@ -4,12 +4,14 @@ import "context"
 
 type contextKey string
 
-func extractHeader(ctx context.Context, header string) (string, bool) {
-	var headerName = contextKey(header)
-	header, ok := ctx.Value(headerName).(string)
-	return header, ok
+const setHeader = contextKey("X-SlogTracer-Set")
+const defaultValue = 1
+
+func extractSetHeader(ctx context.Context) (int, bool) {
+	value, ok := ctx.Value(setHeader).(int)
+	return value, ok
 }
 
-func AddToContext(ctx context.Context, header, value string) context.Context {
-	return context.WithValue(ctx, contextKey(header), value)
+func AddSetHeaderToContext(ctx context.Context, value int) context.Context {
+	return context.WithValue(ctx, setHeader, value)
 }

--- a/handler.go
+++ b/handler.go
@@ -3,35 +3,28 @@ package slogTracer
 import (
 	"context"
 	"log/slog"
-	"strings"
 )
 
 var _ slog.Handler = (*Handler)(nil)
 
 type Handler struct {
 	handler slog.Handler
-	header  string
-	value   string
+	value   int
 }
 
-func NewHandler(handler slog.Handler, headerName, expected string) Handler {
+func NewHandler(handler slog.Handler) Handler {
 	return Handler{
 		handler: handler,
-		header:  headerName,
-		value:   expected,
+		value:   defaultValue,
 	}
 }
 
 func (h Handler) valid(ctx context.Context) bool {
-	header, ok := extractHeader(ctx, h.header)
+	value, ok := extractSetHeader(ctx)
 	if !ok {
 		return false
 	}
-	// HTTP headers are case insensitive
-	if strings.EqualFold(header, h.value) {
-		return true
-	}
-	return false
+	return value == h.value
 }
 
 func (h Handler) Enabled(ctx context.Context, level slog.Level) bool {

--- a/handler_test.go
+++ b/handler_test.go
@@ -83,10 +83,12 @@ func TestLogging(t *testing.T) {
 func BenchmarkHandler(b *testing.B) {
 	handler := slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError})
 	tracerHandler := NewHandler(handler)
+	validCtx := AddSetHeaderToContext(context.Background(), 1)
+	invalidCtx := AddSetHeaderToContext(context.Background(), 2)
+	emptyCtx := context.Background()
 
 	b.Run("valid ctx", func(b *testing.B) {
 		logger := slog.New(tracerHandler)
-		validCtx := context.WithValue(context.Background(), contextKey("setHeader"), 1)
 
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
@@ -96,7 +98,6 @@ func BenchmarkHandler(b *testing.B) {
 
 	b.Run("invalid ctx", func(b *testing.B) {
 		logger := slog.New(tracerHandler)
-		invalidCtx := context.WithValue(context.Background(), contextKey("setHeader"), 1)
 
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
@@ -106,7 +107,6 @@ func BenchmarkHandler(b *testing.B) {
 
 	b.Run("empty ctx", func(b *testing.B) {
 		logger := slog.New(tracerHandler)
-		emptyCtx := context.Background()
 
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {

--- a/handler_test.go
+++ b/handler_test.go
@@ -83,6 +83,7 @@ func TestLogging(t *testing.T) {
 func BenchmarkHandler(b *testing.B) {
 	handler := slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError})
 	tracerHandler := NewHandler(handler)
+
 	validCtx := AddSetHeaderToContext(context.Background(), 1)
 	invalidCtx := AddSetHeaderToContext(context.Background(), 2)
 	emptyCtx := context.Background()
@@ -116,12 +117,10 @@ func BenchmarkHandler(b *testing.B) {
 
 	b.Run("default handler", func(b *testing.B) {
 		logger := slog.New(handler)
-		emptyCtx := context.Background()
 
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			logger.DebugContext(emptyCtx, "test", "key", "label1", "key2", "label2")
 		}
 	})
-
 }


### PR DESCRIPTION
Do not store a string that has to be compared but just an integer. This is quicker.